### PR TITLE
[Feat] 친구 리스트 뷰, 응원하기 뷰 API 연동

### DIFF
--- a/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
+++ b/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		8EE680712929756000D71B64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8EE680702929756000D71B64 /* Assets.xcassets */; };
 		8EF1F74E292D1C9300338342 /* showToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74D292D1C9300338342 /* showToast.swift */; };
 		8EF1F750292E2CE600338342 /* RecordRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */; };
+		B8208B5A292F841800A5DE08 /* FriendListResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */; };
 		B8D2D89B29299A58005F930D /* FriendListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89A29299A58005F930D /* FriendListModel.swift */; };
 		B8D2D89D29299A85005F930D /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89C29299A85005F930D /* FriendListViewController.swift */; };
 		B8D2D89F29299A9C005F930D /* FriendTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */; };
@@ -84,6 +85,7 @@
 		8EE680702929756000D71B64 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8EF1F74D292D1C9300338342 /* showToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = showToast.swift; sourceTree = "<group>"; };
 		8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRequestDto.swift; sourceTree = "<group>"; };
+		B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListResponseDto.swift; sourceTree = "<group>"; };
 		B8D2D89A29299A58005F930D /* FriendListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListModel.swift; sourceTree = "<group>"; };
 		B8D2D89C29299A85005F930D /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
 		B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendTableViewCell.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 			children = (
 				8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */,
 				8EE6805F292933C000D71B64 /* RecordResponseDto.swift */,
+				B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -424,6 +427,7 @@
 				8EE680582929325200D71B64 /* Encodable+.swift in Sources */,
 				8EE6805A2929327800D71B64 /* NetworkLoggerPlugin.swift in Sources */,
 				8EE680692929525300D71B64 /* RecordBottomSheet.swift in Sources */,
+				B8208B5A292F841800A5DE08 /* FriendListResponseDto.swift in Sources */,
 				8EE6804B2929279A00D71B64 /* getClassName.swift in Sources */,
 				B8D2D89F29299A9C005F930D /* FriendTableViewCell.swift in Sources */,
 				8EE68025292925CA00D71B64 /* SceneDelegate.swift in Sources */,

--- a/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
+++ b/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		8EF1F750292E2CE600338342 /* RecordRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */; };
 		B8208B5A292F841800A5DE08 /* FriendListResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */; };
 		B8208B5C292F84C300A5DE08 /* FriendListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */; };
+		B8208B5E292FCBD200A5DE08 /* FriendStoryResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5D292FCBD200A5DE08 /* FriendStoryResponseDto.swift */; };
 		B8D2D89B29299A58005F930D /* FriendListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89A29299A58005F930D /* FriendListModel.swift */; };
 		B8D2D89D29299A85005F930D /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89C29299A85005F930D /* FriendListViewController.swift */; };
 		B8D2D89F29299A9C005F930D /* FriendTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */; };
@@ -88,6 +89,7 @@
 		8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRequestDto.swift; sourceTree = "<group>"; };
 		B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListResponseDto.swift; sourceTree = "<group>"; };
 		B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListRouter.swift; sourceTree = "<group>"; };
+		B8208B5D292FCBD200A5DE08 /* FriendStoryResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendStoryResponseDto.swift; sourceTree = "<group>"; };
 		B8D2D89A29299A58005F930D /* FriendListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListModel.swift; sourceTree = "<group>"; };
 		B8D2D89C29299A85005F930D /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
 		B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendTableViewCell.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */,
 				8EE6805F292933C000D71B64 /* RecordResponseDto.swift */,
 				B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */,
+				B8208B5D292FCBD200A5DE08 /* FriendStoryResponseDto.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 				8EE68027292925CA00D71B64 /* MainViewController.swift in Sources */,
 				8EE6806B292952A100D71B64 /* RecordDetailBottomSheet.swift in Sources */,
 				D60B32A32929408400D9A277 /* RecordModel.swift in Sources */,
+				B8208B5E292FCBD200A5DE08 /* FriendStoryResponseDto.swift in Sources */,
 				B8D2D8A329299ADA005F930D /* StoryViewController.swift in Sources */,
 				D60B32A0292939D500D9A277 /* RecordTableViewCell.swift in Sources */,
 				8EE6804F292927F600D71B64 /* ColorLiterals.swift in Sources */,

--- a/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
+++ b/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		8EF1F74E292D1C9300338342 /* showToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74D292D1C9300338342 /* showToast.swift */; };
 		8EF1F750292E2CE600338342 /* RecordRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */; };
 		B8208B5A292F841800A5DE08 /* FriendListResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */; };
+		B8208B5C292F84C300A5DE08 /* FriendListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */; };
 		B8D2D89B29299A58005F930D /* FriendListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89A29299A58005F930D /* FriendListModel.swift */; };
 		B8D2D89D29299A85005F930D /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89C29299A85005F930D /* FriendListViewController.swift */; };
 		B8D2D89F29299A9C005F930D /* FriendTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */; };
@@ -86,6 +87,7 @@
 		8EF1F74D292D1C9300338342 /* showToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = showToast.swift; sourceTree = "<group>"; };
 		8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRequestDto.swift; sourceTree = "<group>"; };
 		B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListResponseDto.swift; sourceTree = "<group>"; };
+		B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListRouter.swift; sourceTree = "<group>"; };
 		B8D2D89A29299A58005F930D /* FriendListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListModel.swift; sourceTree = "<group>"; };
 		B8D2D89C29299A85005F930D /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
 		B8D2D89E29299A9C005F930D /* FriendTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendTableViewCell.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 			isa = PBXGroup;
 			children = (
 				8EE6805B2929328700D71B64 /* RecordRouter.swift */,
+				B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 				D60B32A7292964FD00D9A277 /* FriendCollectionViewCell.swift in Sources */,
 				1476594C29299D0B008C68C6 /* ReportModel.swift in Sources */,
 				8EE6805C2929328700D71B64 /* RecordRouter.swift in Sources */,
+				B8208B5C292F84C300A5DE08 /* FriendListRouter.swift in Sources */,
 				1476594A29299CFC008C68C6 /* reportTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
+++ b/MyPooDiary/MyPooDiary.xcodeproj/project.pbxproj
@@ -41,7 +41,7 @@
 		8EF1F74E292D1C9300338342 /* showToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74D292D1C9300338342 /* showToast.swift */; };
 		8EF1F750292E2CE600338342 /* RecordRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */; };
 		B8208B5A292F841800A5DE08 /* FriendListResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */; };
-		B8208B5C292F84C300A5DE08 /* FriendListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */; };
+		B8208B5C292F84C300A5DE08 /* FriendsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5B292F84C300A5DE08 /* FriendsRouter.swift */; };
 		B8208B5E292FCBD200A5DE08 /* FriendStoryResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8208B5D292FCBD200A5DE08 /* FriendStoryResponseDto.swift */; };
 		B8D2D89B29299A58005F930D /* FriendListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89A29299A58005F930D /* FriendListModel.swift */; };
 		B8D2D89D29299A85005F930D /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D2D89C29299A85005F930D /* FriendListViewController.swift */; };
@@ -88,7 +88,7 @@
 		8EF1F74D292D1C9300338342 /* showToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = showToast.swift; sourceTree = "<group>"; };
 		8EF1F74F292E2CE600338342 /* RecordRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRequestDto.swift; sourceTree = "<group>"; };
 		B8208B59292F841800A5DE08 /* FriendListResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListResponseDto.swift; sourceTree = "<group>"; };
-		B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListRouter.swift; sourceTree = "<group>"; };
+		B8208B5B292F84C300A5DE08 /* FriendsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRouter.swift; sourceTree = "<group>"; };
 		B8208B5D292FCBD200A5DE08 /* FriendStoryResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendStoryResponseDto.swift; sourceTree = "<group>"; };
 		B8D2D89A29299A58005F930D /* FriendListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListModel.swift; sourceTree = "<group>"; };
 		B8D2D89C29299A85005F930D /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
@@ -262,7 +262,7 @@
 			isa = PBXGroup;
 			children = (
 				8EE6805B2929328700D71B64 /* RecordRouter.swift */,
-				B8208B5B292F84C300A5DE08 /* FriendListRouter.swift */,
+				B8208B5B292F84C300A5DE08 /* FriendsRouter.swift */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -443,7 +443,7 @@
 				D60B32A7292964FD00D9A277 /* FriendCollectionViewCell.swift in Sources */,
 				1476594C29299D0B008C68C6 /* ReportModel.swift in Sources */,
 				8EE6805C2929328700D71B64 /* RecordRouter.swift in Sources */,
-				B8208B5C292F84C300A5DE08 /* FriendListRouter.swift in Sources */,
+				B8208B5C292F84C300A5DE08 /* FriendsRouter.swift in Sources */,
 				1476594A29299CFC008C68C6 /* reportTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyPooDiary/MyPooDiary/Network/DTO/FriendListResponseDto.swift
+++ b/MyPooDiary/MyPooDiary/Network/DTO/FriendListResponseDto.swift
@@ -1,0 +1,21 @@
+//
+//  FriendListResponseDto.swift
+//  MyPooDiary
+//
+//  Created by 박의서 on 2022/11/24.
+//
+
+import Foundation
+
+// MARK: - FriendListResponseDto
+struct FriendListResponseDto: Codable {
+    let status: Int
+    let message: String
+    let data: [FriendListResponseData]
+}
+
+// MARK: - Datum
+struct FriendListResponseData: Codable {
+    let name: String
+    let isSupported: Bool
+}

--- a/MyPooDiary/MyPooDiary/Network/DTO/FriendListResponseDto.swift
+++ b/MyPooDiary/MyPooDiary/Network/DTO/FriendListResponseDto.swift
@@ -18,4 +18,9 @@ struct FriendListResponseDto: Codable {
 struct FriendListResponseData: Codable {
     let name: String
     let isSupported: Bool
+    
+    
+    func convertToFriendListModel() -> FriendListModel {
+        return FriendListModel(friendImage: "friend", name: self.name)
+    }
 }

--- a/MyPooDiary/MyPooDiary/Network/DTO/FriendStoryResponseDto.swift
+++ b/MyPooDiary/MyPooDiary/Network/DTO/FriendStoryResponseDto.swift
@@ -1,0 +1,58 @@
+//
+//  FriendStoryResponseDto.swift
+//  MyPooDiary
+//
+//  Created by 박의서 on 2022/11/25.
+//
+
+import Foundation
+
+// MARK: - FriendStoryResponseDto
+struct FriendStoryResponseDto: Codable {
+    let status: Int
+    let message: String
+    let data: FriendStoryResponseData
+}
+
+// MARK: - DataClass
+struct FriendStoryResponseData: Codable {
+    let recordID, user: Int
+    let satisfy: Bool
+    let color, strength: JSONNull?
+    let supportCnt: Int
+    let date: String
+
+    enum CodingKeys: String, CodingKey {
+        case recordID = "recordId"
+        case user, satisfy, color, strength
+        case supportCnt = "support_cnt"
+        case date
+    }
+}
+
+// MARK: - Encode/decode helpers
+
+class JSONNull: Codable, Hashable {
+
+    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
+        return true
+    }
+
+    public var hashValue: Int {
+        return 0
+    }
+
+    public init() {}
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if !container.decodeNil() {
+            throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encodeNil()
+    }
+}

--- a/MyPooDiary/MyPooDiary/Network/DTO/FriendStoryResponseDto.swift
+++ b/MyPooDiary/MyPooDiary/Network/DTO/FriendStoryResponseDto.swift
@@ -18,7 +18,7 @@ struct FriendStoryResponseDto: Codable {
 struct FriendStoryResponseData: Codable {
     let recordID, user: Int
     let satisfy: Bool
-    let color, strength: JSONNull?
+    let color, strength: Int?
     let supportCnt: Int
     let date: String
 
@@ -30,29 +30,3 @@ struct FriendStoryResponseData: Codable {
     }
 }
 
-// MARK: - Encode/decode helpers
-
-class JSONNull: Codable, Hashable {
-
-    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
-        return true
-    }
-
-    public var hashValue: Int {
-        return 0
-    }
-
-    public init() {}
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if !container.decodeNil() {
-            throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encodeNil()
-    }
-}

--- a/MyPooDiary/MyPooDiary/Network/Router/FriendListRouter.swift
+++ b/MyPooDiary/MyPooDiary/Network/Router/FriendListRouter.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 enum FriendListRouter {
-    case fetchFriendList(param: FriendListResponseDto)
+    case fetchFriendList
 }
 
 extension FriendListRouter: TargetType {
@@ -34,8 +34,8 @@ extension FriendListRouter: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .fetchFriendList(let param):
-            return .requestJSONEncodable(param)
+        case .fetchFriendList:
+            return .requestPlain
         }
     }
     

--- a/MyPooDiary/MyPooDiary/Network/Router/FriendListRouter.swift
+++ b/MyPooDiary/MyPooDiary/Network/Router/FriendListRouter.swift
@@ -1,0 +1,46 @@
+//
+//  FriendListRouter.swift
+//  MyPooDiary
+//
+//  Created by 박의서 on 2022/11/24.
+//
+
+
+import Foundation
+import Moya
+
+enum FriendListRouter {
+    case fetchFriendList(param: FriendListResponseDto)
+}
+
+extension FriendListRouter: TargetType {
+    var baseURL: URL {
+        return URL(string: APIConstants.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchFriendList:
+            return "/friend"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchFriendList:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .fetchFriendList(let param):
+            return .requestJSONEncodable(param)
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+    
+}

--- a/MyPooDiary/MyPooDiary/Network/Router/FriendsRouter.swift
+++ b/MyPooDiary/MyPooDiary/Network/Router/FriendsRouter.swift
@@ -1,5 +1,5 @@
 //
-//  FriendListRouter.swift
+//  FriendsRouter.swift
 //  MyPooDiary
 //
 //  Created by 박의서 on 2022/11/24.
@@ -9,11 +9,11 @@
 import Foundation
 import Moya
 
-enum FriendListRouter {
+enum FriendsRouter {
     case fetchFriendList
 }
 
-extension FriendListRouter: TargetType {
+extension FriendsRouter: TargetType {
     var baseURL: URL {
         return URL(string: APIConstants.baseURL)!
     }

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
@@ -53,6 +53,10 @@ final class FriendListViewController: UIViewController {
         setLayout()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        getFriendList()
+    }
+    
     // MARK: - Functions
 
     // MARK: - @objc Function
@@ -139,8 +143,8 @@ extension FriendListViewController: UITableViewDataSource {
 // MARK: - Network
 
 extension FriendListViewController {
-    private func getFriendList(param: FriendListResponseDto) {
-        friendListProvider.request(.fetchFriendList(param: param)) { response in
+    private func getFriendList() {
+        friendListProvider.request(.fetchFriendList) { response in
             switch response {
             case .success(let result):
                 let status = result.statusCode

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
@@ -144,6 +144,7 @@ extension FriendListViewController: UITableViewDataSource {
 
 extension FriendListViewController {
     private func getFriendList() {
+        friendList = []
         friendListProvider.request(.fetchFriendList) { response in
             switch response {
             case .success(let result):

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
@@ -137,6 +137,7 @@ extension FriendListViewController: UITableViewDataSource {
         let friendViewController = FriendViewController()
         friendViewController.modalPresentationStyle = .overFullScreen
         self.present(friendViewController, animated: true)
+        friendViewController.bindFriendIndex(index: indexPath.row)
     }
 }
     

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
@@ -15,7 +15,7 @@ import Moya
 final class FriendListViewController: UIViewController {
 
     // MARK: - Properties
-    let friendListProvider = MoyaProvider<FriendListRouter>(plugins: [NetworkLoggerPlugin(verbose: true)])
+    let friendListProvider = MoyaProvider<FriendsRouter>(plugins: [NetworkLoggerPlugin(verbose: true)])
     
     var friendList: [FriendListModel] = [
         FriendListModel(friendImage: "friend", name: "이길동"),

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendListViewController.swift
@@ -18,18 +18,18 @@ final class FriendListViewController: UIViewController {
     let friendListProvider = MoyaProvider<FriendListRouter>(plugins: [NetworkLoggerPlugin(verbose: true)])
     
     var friendList: [FriendListModel] = [
-        FriendListModel(friendImage: "icon_profile", name: "이길동"),
-        FriendListModel(friendImage: "icon_profile", name: "노한솔"),
-        FriendListModel(friendImage: "icon_profile", name: "박의서"),
-        FriendListModel(friendImage: "icon_profile", name: "김유빈"),
-        FriendListModel(friendImage: "icon_profile", name: "이승헌"),
-        FriendListModel(friendImage: "icon_profile", name: "김은수"),
-        FriendListModel(friendImage: "icon_profile", name: "윤수빈"),
-        FriendListModel(friendImage: "icon_profile", name: "김인영"),
-        FriendListModel(friendImage: "icon_profile", name: "이화정"),
-        FriendListModel(friendImage: "icon_profile", name: "전희선"),
-        FriendListModel(friendImage: "icon_profile", name: "손혜정"),
-        FriendListModel(friendImage: "icon_profile", name: "박서원")
+        FriendListModel(friendImage: "friend", name: "이길동"),
+        FriendListModel(friendImage: "friend", name: "노한솔"),
+        FriendListModel(friendImage: "friend", name: "박의서"),
+        FriendListModel(friendImage: "friend", name: "김유빈"),
+        FriendListModel(friendImage: "friend", name: "이승헌"),
+        FriendListModel(friendImage: "friend", name: "김은수"),
+        FriendListModel(friendImage: "friend", name: "윤수빈"),
+        FriendListModel(friendImage: "friend", name: "김인영"),
+        FriendListModel(friendImage: "friend", name: "이화정"),
+        FriendListModel(friendImage: "friend", name: "전희선"),
+        FriendListModel(friendImage: "friend", name: "손혜정"),
+        FriendListModel(friendImage: "friend", name: "박서원")
     ]
     
     // MARK: - UI

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendViewController.swift
@@ -15,7 +15,7 @@ import Moya
 final class FriendViewController: UIViewController {
 
     // MARK: - Properties
-    let friendListProvider = MoyaProvider<FriendListRouter>(plugins: [NetworkLoggerPlugin(verbose: true)])
+    let friendListProvider = MoyaProvider<FriendsRouter>(plugins: [NetworkLoggerPlugin(verbose: true)])
     var friendIndex: Int = 0
     
     // MARK: - UI

--- a/MyPooDiary/MyPooDiary/Screens/Friends/FriendViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Friends/FriendViewController.swift
@@ -45,7 +45,7 @@ final class FriendViewController: UIViewController {
         $0.text = "이길동님의 변기록이에요"
         $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
-    private lazy var userProfilesImage = makeImageView("userProfiles")
+    private lazy var userProfilesImage = makeImageView("user")
     private var cheeringLabel = UILabel().then {
         $0.text = "박서현님 외 12명이 응원하고 있어요!"
         $0.font = .systemFont(ofSize: 16)

--- a/MyPooDiary/MyPooDiary/Screens/Story/StoryViewController.swift
+++ b/MyPooDiary/MyPooDiary/Screens/Story/StoryViewController.swift
@@ -25,7 +25,7 @@ final class StoryViewController: UIViewController {
         $0.addTarget(self, action: #selector(touchUpCheeringButton), for: .touchUpInside)
     }
     
-    private lazy var backButton = makeButton("white-back-button").then {
+    private lazy var backButton = makeButton("Expand_left").then {
         $0.addTarget(self, action: #selector(touchUpBackButton), for: .touchUpInside)
     }
     private var didPooLabel = UILabel().then {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#19

👷 **작업한 내용**
- 친구 리스트 뷰 API 연동: 서버의 친구 리스트 불러온 후 테이블뷰에 적용
- 응원하기 뷰 API 연동: 친구 스토리 뷰의 친구 이름 변경

## 🚨참고 사항
FriendsRouter 연동 위한 중간 PR

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📟 관련 이슈
- Resolved: #19
